### PR TITLE
Update development environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,13 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
-  - repo: https://github.com/lasuillard-s/devobs
-    rev: v0.2.6
+  - repo: local
     hooks:
       - id: check-file-pair
+        name: check-file-pair
+        language: system
+        entry: uv tool run devobs check-file-pair
+        pass_filenames: false
         args:
           - --from=pulumi_extra
           - --to=tests
@@ -18,8 +21,6 @@ repos:
           - --expect={to}/{relative_from}/test_{filename}
           - --create-if-not-exists
 
-  - repo: local
-    hooks:
       - id: ruff-check
         name: ruff check
         language: system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,6 @@ This repository uses [Nix Flakes](https://nix.dev/concepts/flakes.html) to manag
 - `pre-commit`
 - `just`
 - `uv`
-- `pipx`
 - Pulumi CLI (`pulumi`)
 
 Simply run `nix develop` to enter the development environment, then run `just install` to install dependencies. The Nix shell also installs the pre-commit hooks automatically.

--- a/flake.nix
+++ b/flake.nix
@@ -14,13 +14,6 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
-
-        # BUG: https://github.com/nixos/nixpkgs/issues/522307
-        fixedPipx = pkgs.python3Packages.toPythonApplication (
-          pkgs.python3Packages.pipx.overridePythonAttrs (oldAttrs: {
-            doCheck = false;
-          })
-        );
       in
       {
         devShells.default = pkgs.mkShell {
@@ -28,11 +21,13 @@
             pre-commit
             just
             uv
-            fixedPipx
             pulumi
           ];
           shellHook = ''
             pre-commit install
+
+            # Workaround for pre-commit dependency leak
+            unset PYTHONPATH
           '';
         };
       }


### PR DESCRIPTION
- Use `uv tool run` instead of `pipx` used internally by `devobs` pre-commit hooks
- Remove unused `pipx` from tool list
- Workaround fix for pre-commit dependency leak (pytest)